### PR TITLE
add missing backtick for inline code

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ interface Node {
 ```
 
 The `type` field is a string representing the type of Node the object is (ie.
-`"FunctionDeclaration"`, `"Identifier", or `"BinaryExpression"`). Each type of
+`"FunctionDeclaration"`, `"Identifier"`, or `"BinaryExpression"`). Each type of
 Node defines an additional set of properties that describe that particular node
 type.
 


### PR DESCRIPTION
Add a missing backtick causing the sentence "*(ie. `"FunctionDeclaration"`, `"Identifier"`, or `"BinaryExpression"`)*" to look badly formatted.