### PR TITLE
update babel-types import

### DIFF
--- a/README.md
+++ b/README.md
@@ -894,7 +894,7 @@ Then start using it:
 
 ```js
 import traverse from "babel-traverse";
-import t from "babel-types";
+import * as t from "babel-types";
 
 traverse(ast, {
   enter(path) {


### PR DESCRIPTION
Default import for latest ```babel-types``` gives an ```undefined```. This will import all the modules.