### PR TITLE
Add link to `babel-core`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1156,7 +1156,7 @@ var myModule = require("my-module");
 Now that you're familiar with all the basics of Babel, let's tie it together
 with the plugin API.
 
-Start off with a `function` that gets passed the current `babel` object.
+Start off with a `function` that gets passed the current [`babel`](https://github.com/babel/babel/tree/master/packages/babel-core) object.
 
 ```js
 export default function(babel) {


### PR DESCRIPTION
To be a little more explicit what the "current `babel`  object" is and hopefully avoid future questions [like this](https://babeljs.slack.com/archives/plugins/p1452695391000578) in the future 😀