### PR TITLE
Updated preset documentation to use a function export instead of an object export.

### DIFF
--- a/translations/en/user-handbook.md
+++ b/translations/en/user-handbook.md
@@ -747,7 +747,7 @@ Then create an `index.js` file that exports a function that returns the contents
 file, replacing plugin/preset strings with `require` calls.
 
 ```js
-module.exports = () => {
+module.exports = () => ({
   presets: [
     require("babel-preset-es2015"),
     require("babel-preset-react")
@@ -755,7 +755,7 @@ module.exports = () => {
   plugins: [
     require("babel-plugin-transform-flow-strip-types")
   ]
-};
+});
 ```
 
 Then simply publish this to npm and you can use it like you would any preset.

--- a/translations/en/user-handbook.md
+++ b/translations/en/user-handbook.md
@@ -743,11 +743,11 @@ your preset.
 }
 ```
 
-Then create an `index.js` file that exports the contents of your `.babelrc`
+Then create an `index.js` file that exports a function that returns the contents of your `.babelrc`
 file, replacing plugin/preset strings with `require` calls.
 
 ```js
-module.exports = {
+module.exports = () => {
   presets: [
     require("babel-preset-es2015"),
     require("babel-preset-react")


### PR DESCRIPTION
Babel 7 expects the `index.js` file to return a function instead of an object. This is also in [their docs](https://babeljs.io/docs/en/presets#creating-a-preset).

When you try to export an object instead of a function, the following error will appear in the console:

<img width="799" alt="babel-custom-preset-console-error" src="https://user-images.githubusercontent.com/1598330/49253746-a42b4080-f427-11e8-9cde-1659ff4c6b03.png">
