### PR TITLE
Remove file name from `buildCodeFrameError` result

### DIFF
--- a/translations/en/plugin-handbook.md
+++ b/translations/en/plugin-handbook.md
@@ -1835,7 +1835,7 @@ export default function({ types: t }) {
 The error looks like:
 
 ```
-file.js: Error message here
+Error message here
    7 |
    8 | let tips = [
 >  9 |   "Click on any AST node with a '+' to expand it",


### PR DESCRIPTION
Remove the file name from the `buildCodeFrameError` example result. The file name was removed in PR https://github.com/babel/babel/pull/10539. It confused me since I was expecting the file name there, but it wasn't.