### PR TITLE
Change new link of source maps

### DIFF
--- a/translations/en/plugin-handbook.md
+++ b/translations/en/plugin-handbook.md
@@ -318,7 +318,7 @@ So we won't dive too deep right now.
 
 The [code generation](https://en.wikipedia.org/wiki/Code_generation_(compiler))
 stage takes the final AST and turns it back into a string of code, also creating
-[source maps](http://www.html5rocks.com/en/tutorials/developertools/sourcemaps/).
+[source maps](https://developer.chrome.com/blog/sourcemaps/).
 
 Code generation is pretty simple: you traverse through the AST depth-first,
 building a string that represents the transformed code.


### PR DESCRIPTION
The previous link of Source Maps invalid now, and change it to a new link.

previous link: http://www.html5rocks.com/en/tutorials/developertools/sourcemaps/
new link:  https://developer.chrome.com/blog/sourcemaps